### PR TITLE
feat: Skip hidden files and directories

### DIFF
--- a/batch_jxl_compress.py
+++ b/batch_jxl_compress.py
@@ -323,8 +323,11 @@ def build_tasks(args) -> Tuple[List[EncodeTask], List[EncodeResult]]:
 
   # Walk
   for dirpath, _dirnames, filenames in os.walk(root):
+    # Prune hidden directories and files
+    _dirnames[:] = [d for d in _dirnames if not d.startswith('.')]
+
     dirpath_p = Path(dirpath)
-    for name in filenames:
+    for name in (f for f in filenames if not f.startswith('.')):
       src = dirpath_p / name
       if src.is_symlink():
         continue  # skip symlinks


### PR DESCRIPTION
The script now avoids traversing hidden directories (like `.thumbnails`) and processing hidden files (like `.DS_Store`).

This is achieved by modifying the `os.walk` loop in the `build_tasks` function to filter out any directory or file starting with a dot.